### PR TITLE
Check if project_path list is empty

### DIFF
--- a/uetools/commands/init.py
+++ b/uetools/commands/init.py
@@ -64,7 +64,8 @@ class Init(Command):
                 project_paths = [project_paths]
 
             default_engine = conf.get("engine_path", default_engine)
-            default_project = project_paths[0]
+            if len(project_paths) != 0:
+                default_project = project_paths[0]
 
         if args.engine is None:
             engine_path = input(f"Engine Folder [{default_engine}]: ")


### PR DESCRIPTION
when init the uecli and the system already has a `uecli/loc.json`, and the project_path and engine_path are empty:

`uecli init --engine C:/opt/UnrealEngine/Engine --projects C:/opt/Projects`

it will index the empty list:
```
    default_project = project_paths[0]
                      ~~~~~~~~~~~~~^^^
IndexError: list index out of range
```

this could happen when the user try to executes a command for adding a non project/engine_path when the config file does not exist:

```
uecli engine add --version xxx --engine '/path/to/ue/Engine' 
```